### PR TITLE
feat(prisma): add Stock and Beneficiary repositories with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,46 @@ dans ./backend
 npx drizzle-kit push
 
 npm run db:seed:all:drizzle
+
+## Tests Prisma
+
+Les tests Prisma nécessitent une base de données PostgreSQL de test.
+
+### Option 1 : Avec Docker (recommandé)
+
+```bash
+# 1. Démarrer un conteneur PostgreSQL de test
+docker run --name postgres-test -e POSTGRES_PASSWORD=test -e POSTGRES_DB=cleanavenir_test -p 5433:5432 -d postgres
+
+# 2. Définir l'URL de la base de test
+export DATABASE_URL_TEST="postgresql://postgres:test@localhost:5433/cleanavenir_test"
+
+# 3. Synchroniser le schéma Prisma
+cd backend
+DATABASE_URL=$DATABASE_URL_TEST npx prisma db push --schema=src/infrastructure/repositories/prisma/schema.prisma
+
+# 4. Lancer les tests Prisma
+npm test -- prisma-stock-repo.test.ts prisma-beneficiary-repo.test.ts
+```
+
+### Option 2 : Avec une base PostgreSQL existante
+
+```bash
+# 1. Créer une base de données de test
+psql -U postgres -c "CREATE DATABASE cleanavenir_test;"
+
+# 2. Définir l'URL de la base de test
+export DATABASE_URL_TEST="postgresql://postgres:votre_mot_de_passe@localhost:5432/cleanavenir_test"
+
+# 3. Synchroniser le schéma et lancer les tests
+cd backend
+DATABASE_URL=$DATABASE_URL_TEST npx prisma db push --schema=src/infrastructure/repositories/prisma/schema.prisma
+npm test -- prisma-stock-repo.test.ts prisma-beneficiary-repo.test.ts
+```
+
+### Lancer tous les tests
+
+```bash
+cd backend
+npm test
+```

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@libsql/client": "^0.15.15",
+        "@prisma/adapter-pg": "^7.2.0",
         "@prisma/client": "^7.1.0",
         "@types/bcrypt": "^6.0.0",
         "@types/cookie-parser": "^1.4.10",
@@ -27,6 +28,7 @@
         "jsonwebtoken": "^9.0.2",
         "node-cron": "^4.2.1",
         "pdfkit": "^0.17.2",
+        "pg": "^8.16.3",
         "swagger-jsdoc": "^6.2.8",
         "swagger-ui-express": "^5.0.1",
         "winston": "^3.18.3"
@@ -1632,6 +1634,17 @@
         "@noble/hashes": "^1.1.5"
       }
     },
+    "node_modules/@prisma/adapter-pg": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@prisma/adapter-pg/-/adapter-pg-7.2.0.tgz",
+      "integrity": "sha512-euIdQ13cRB2wZ3jPsnDnFhINquo1PYFPCg6yVL8b2rp3EdinQHsX9EDdCtRr489D5uhphcRk463OdQAFlsCr0w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/driver-adapter-utils": "7.2.0",
+        "pg": "^8.16.3",
+        "postgres-array": "3.0.4"
+      }
+    },
     "node_modules/@prisma/client": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/@prisma/client/-/client-7.1.0.tgz",
@@ -1707,6 +1720,21 @@
         "valibot": "1.2.0",
         "zeptomatch": "2.0.2"
       }
+    },
+    "node_modules/@prisma/driver-adapter-utils": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@prisma/driver-adapter-utils/-/driver-adapter-utils-7.2.0.tgz",
+      "integrity": "sha512-gzrUcbI9VmHS24Uf+0+7DNzdIw7keglJsD5m/MHxQOU68OhGVzlphQRobLiDMn8CHNA2XN8uugwKjudVtnfMVQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "7.2.0"
+      }
+    },
+    "node_modules/@prisma/driver-adapter-utils/node_modules/@prisma/debug": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-7.2.0.tgz",
+      "integrity": "sha512-YSGTiSlBAVJPzX4ONZmMotL+ozJwQjRmZweQNIq/ER0tQJKJynNkRB3kyvt37eOfsbMCXk3gnLF6J9OJ4QWftw==",
+      "license": "Apache-2.0"
     },
     "node_modules/@prisma/engines": {
       "version": "7.1.0",
@@ -6500,6 +6528,104 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/pg": {
+      "version": "8.16.3",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
+      "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.9.1",
+        "pg-pool": "^3.10.1",
+        "pg-protocol": "^1.10.3",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.2.7"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.2.7.tgz",
+      "integrity": "sha512-YgCtzMH0ptvZJslLM1ffsY4EuGaU0cx4XSdXLRFae8bPP4dS5xL1tNB3k2o/N64cHJpwU7dxKli/nZ2lUa5fLg==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.9.1.tgz",
+      "integrity": "sha512-nkc6NpDcvPVpZXxrreI/FOtX3XemeLl8E0qFr6F2Lrm/I8WOnaWNhIPK2Z7OHpw7gh5XJThi6j6ppgNoaT1w4w==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.10.1.tgz",
+      "integrity": "sha512-Tu8jMlcX+9d8+QVzKIvM/uJtp07PKr82IUOYEphaWcoBhIYkoHpLXN3qO59nAI11ripznDsEzEv8nUxBVWajGg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.10.3.tgz",
+      "integrity": "sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pg-types/node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -6591,6 +6717,45 @@
       "funding": {
         "type": "individual",
         "url": "https://github.com/sponsors/porsager"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-3.0.4.tgz",
+      "integrity": "sha512-nAUSGfSDGOaOAEGwqsRY27GPOea7CNipJPOA7lPbdEpx5Kg3qzdP0AaWC5MlhTWV9s4hFX39nomVZ+C4tnGOJQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/prelude-ls": {
@@ -7310,6 +7475,15 @@
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/sqlstring": {
@@ -8713,6 +8887,15 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
       }
     },
     "node_modules/yaml": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -81,6 +81,7 @@
   },
   "dependencies": {
     "@libsql/client": "^0.15.15",
+    "@prisma/adapter-pg": "^7.2.0",
     "@prisma/client": "^7.1.0",
     "@types/bcrypt": "^6.0.0",
     "@types/cookie-parser": "^1.4.10",
@@ -98,6 +99,7 @@
     "jsonwebtoken": "^9.0.2",
     "node-cron": "^4.2.1",
     "pdfkit": "^0.17.2",
+    "pg": "^8.16.3",
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^5.0.1",
     "winston": "^3.18.3"

--- a/backend/src/infrastructure/prismaBootstrap/prismaContainer.ts
+++ b/backend/src/infrastructure/prismaBootstrap/prismaContainer.ts
@@ -33,6 +33,7 @@ import { GetCurrentSavingRateUseCase } from '../../application/use-cases/client/
 // Repositories Prisma
 import { PrismaAdvisorRepository } from '../repositories/prisma/PrismaAdvisorRepository';
 import { PrismaBankAccountRepository } from '../repositories/prisma/PrismaBankAccountRepository';
+import { PrismaBeneficiaryRepository } from '../repositories/prisma/PrismaBeneficiaryRepository';
 import { PrismaClientRepository } from '../repositories/prisma/PrismaClientRepository';
 import { PrismaCompanyRepository } from '../repositories/prisma/PrismaCompanyRepository';
 import { PrismaDirectorRepository } from '../repositories/prisma/PrismaDirectorRepository';
@@ -42,6 +43,7 @@ import { PrismaLoanRepository } from '../repositories/prisma/PrismaLoanRepositor
 import { PrismaPortfolioRepository } from '../repositories/prisma/PrismaPortfolioRepository';
 import { PrismaSavingAccountRepository } from '../repositories/prisma/PrismaSavingAccountRepository';
 import { PrismaSavingProductRepository } from '../repositories/prisma/PrismaSavingProductRepository';
+import { PrismaStockRepository } from '../repositories/prisma/PrismaStockRepository';
 import { PrismaTradeRepository } from '../repositories/prisma/PrismaTradeRepository';
 import { PrismaTransactionRepository } from '../repositories/prisma/PrismaTransactionRepository';
 import { PrismaUserRepository } from '../repositories/prisma/PrismaUserRepository';
@@ -49,6 +51,7 @@ import { PrismaUserRepository } from '../repositories/prisma/PrismaUserRepositor
 // Mappers
 import { PrismaAdvisorMapper } from '../repositories/mappers/PrismaMappers/PrismaAdvisorMapper';
 import { PrismaBankAccountMapper } from '../repositories/mappers/PrismaMappers/PrismaBankAccountMapper';
+import { PrismaBeneficiaryMapper } from '../repositories/mappers/PrismaMappers/PrismaBeneficiaryMapper';
 import { PrismaClientMapper } from '../repositories/mappers/PrismaMappers/PrismaClientMapper';
 import { PrismaCompanyMapper } from '../repositories/mappers/PrismaMappers/PrismaCompanyMapper';
 import { PrismaDirectorMapper } from '../repositories/mappers/PrismaMappers/PrismaDirectorMapper';
@@ -58,6 +61,7 @@ import { PrismaLoanMapper } from '../repositories/mappers/PrismaMappers/PrismaLo
 import { PrismaPortfolioMapper } from '../repositories/mappers/PrismaMappers/PrismaPortfolioMapper';
 import { PrismaSavingAccountMapper } from '../repositories/mappers/PrismaMappers/PrismaSavingAccountMapper';
 import { PrismaSavingProductMapper } from '../repositories/mappers/PrismaMappers/PrismaSavingProductMapper';
+import { PrismaStockMapper } from '../repositories/mappers/PrismaMappers/PrismaStockMapper';
 import { PrismaTradeMapper } from '../repositories/mappers/PrismaMappers/PrismaTradeMapper';
 import { PrismaTransactionMapper } from '../repositories/mappers/PrismaMappers/PrismaTransactionMapper';
 import { PrismaUserMapper } from '../repositories/mappers/PrismaMappers/PrismaUserMapper';
@@ -72,9 +76,11 @@ export function createPrismaContainer() {
   const directorMapper = new PrismaDirectorMapper();
   const advisorMapper = new PrismaAdvisorMapper();
   const bankAccountMapper = new PrismaBankAccountMapper();
+  const beneficiaryMapper = new PrismaBeneficiaryMapper();
   const loanMapper = new PrismaLoanMapper();
   const savingAccountMapper = new PrismaSavingAccountMapper();
   const savingProductMapper = new PrismaSavingProductMapper();
+  const stockMapper = new PrismaStockMapper();
   const transactionMapper = new PrismaTransactionMapper();
   const tradeMapper = new PrismaTradeMapper();
   const portfolioMapper = new PrismaPortfolioMapper();
@@ -87,9 +93,11 @@ export function createPrismaContainer() {
   const directorRepository = new PrismaDirectorRepository(prismaClient, directorMapper);
   const advisorRepository = new PrismaAdvisorRepository(prismaClient, advisorMapper);
   const bankAccountRepository = new PrismaBankAccountRepository(prismaClient, bankAccountMapper);
+  const beneficiaryRepository = new PrismaBeneficiaryRepository(prismaClient, beneficiaryMapper);
   const loanRepository = new PrismaLoanRepository(prismaClient, loanMapper);
   const savingAccountRepository = new PrismaSavingAccountRepository(prismaClient, savingAccountMapper);
   const savingProductRepository = new PrismaSavingProductRepository(prismaClient, savingProductMapper);
+  const stockRepository = new PrismaStockRepository(prismaClient, stockMapper);
   const transactionRepository = new PrismaTransactionRepository(prismaClient, transactionMapper);
   const tradeRepository = new PrismaTradeRepository(prismaClient, tradeMapper);
   const portfolioRepository = new PrismaPortfolioRepository(prismaClient, portfolioMapper);

--- a/backend/src/infrastructure/repositories/mappers/PrismaMappers/PrismaBeneficiaryMapper.ts
+++ b/backend/src/infrastructure/repositories/mappers/PrismaMappers/PrismaBeneficiaryMapper.ts
@@ -1,0 +1,42 @@
+import { Mapper } from "../MapperInterface";
+import { Beneficiary as PrismaBeneficiary } from "@prisma/client";
+import { Beneficiary } from "../../../../domain/entities/Beneficiary";
+import { Iban } from "../../../../domain/value-objects/Iban";
+
+type BeneficiaryToPersist = {
+  beneficiaryIdentifier: string;
+  clientIdentifier: string;
+  iban: string;
+  label: string;
+  accountName: string | null;
+  createdAt: Date;
+}
+
+export class PrismaBeneficiaryMapper implements Mapper<PrismaBeneficiary, Beneficiary, BeneficiaryToPersist> {
+  toDomain(raw: PrismaBeneficiary): Beneficiary {
+    const ibanResult = Iban.from(raw.iban);
+    if (!ibanResult.ok) {
+      throw new Error(`Invalid IBAN format: ${raw.iban}`);
+    }
+    
+    return Beneficiary.create({
+      beneficiaryIdentifier: raw.beneficiaryIdentifier,
+      clientIdentifier: raw.clientIdentifier,
+      iban: ibanResult.value,
+      label: raw.label,
+      createdAt: raw.createdAt,
+      accountName: raw.accountName ?? undefined
+    });
+  }
+
+  toPersistence(obj: Beneficiary): BeneficiaryToPersist {
+    return {
+      beneficiaryIdentifier: obj.beneficiaryIdentifier,
+      clientIdentifier: obj.clientIdentifier,
+      iban: obj.iban.value,
+      label: obj.label,
+      accountName: obj.accountName ?? null,
+      createdAt: obj.createdAt
+    };
+  }
+}

--- a/backend/src/infrastructure/repositories/mappers/PrismaMappers/PrismaStockMapper.ts
+++ b/backend/src/infrastructure/repositories/mappers/PrismaMappers/PrismaStockMapper.ts
@@ -14,12 +14,22 @@ type StockToPersist = {
 export class PrismaStockMapper implements Mapper<PrismaStock, Stock, StockToPersist> {
   toDomain(raw: PrismaStock): Stock {
     return Stock.create({
-      ...raw,
-      ticker: new Ticker(raw.ticker)
+      stockIdentifier: raw.stockIdentifier,
+      companyIdentifier: raw.companyIdentifier,
+      ticker: new Ticker(raw.ticker),
+      price: raw.price,
+      isAvailable: raw.isAvailable,
+      createdAt: new Date() // Prisma schema n'a pas createdAt, on utilise Date actuelle
     })
   }
 
   toPersistence(obj: Stock): StockToPersist {
-    return {...obj, ticker: obj.ticker.value}
+    return {
+      stockIdentifier: obj.stockIdentifier,
+      companyIdentifier: obj.companyIdentifier,
+      ticker: obj.ticker.value,
+      price: obj.price,
+      isAvailable: obj.isAvailable
+    }
   }
 }

--- a/backend/src/infrastructure/repositories/prisma/PrismaBeneficiaryRepository.ts
+++ b/backend/src/infrastructure/repositories/prisma/PrismaBeneficiaryRepository.ts
@@ -1,0 +1,101 @@
+import { PrismaClient } from "@prisma/client";
+import { BeneficiaryRepository } from "../../../application/ports/repositories/BeneficiaryRepository";
+import { Beneficiary } from "../../../domain/entities/Beneficiary";
+import { BeneficiaryNotFoundError } from "../../../domain/errors/BeneficiaryNotFoundError";
+import { UnexpectedBeneficiaryError } from "../../../domain/errors/UnexpectedBeneficiaryError";
+import Result, { err, ok } from "../../../shared/Result";
+import { PrismaBeneficiaryMapper } from "../mappers/PrismaMappers/PrismaBeneficiaryMapper";
+
+export class PrismaBeneficiaryRepository implements BeneficiaryRepository {
+  constructor(
+    private readonly prismaClient: PrismaClient,
+    private readonly prismaBeneficiaryMapper: PrismaBeneficiaryMapper
+  ) {}
+
+  async save(beneficiary: Beneficiary): Promise<Result<Beneficiary, Error>> {
+    try {
+      const beneficiaryToPersist = this.prismaBeneficiaryMapper.toPersistence(beneficiary);
+      const registered = await this.prismaClient.beneficiary.create({
+        data: { ...beneficiaryToPersist }
+      });
+      return ok(this.prismaBeneficiaryMapper.toDomain(registered));
+    } catch (error: any) {
+      return err(new Error(`Error saving beneficiary: ${error.message}`));
+    }
+  }
+
+  async findById(beneficiaryIdentifier: string): Promise<Result<Beneficiary, BeneficiaryNotFoundError | UnexpectedBeneficiaryError>> {
+    try {
+      const maybeBeneficiary = await this.prismaClient.beneficiary.findUnique({
+        where: { beneficiaryIdentifier }
+      });
+
+      if (!maybeBeneficiary) {
+        return err(new BeneficiaryNotFoundError(beneficiaryIdentifier));
+      }
+
+      return ok(this.prismaBeneficiaryMapper.toDomain(maybeBeneficiary));
+    } catch (error: any) {
+      return err(new UnexpectedBeneficiaryError(`Error fetching beneficiary: ${error.message}`, error));
+    }
+  }
+
+  async findByClientIdentifier(clientIdentifier: string): Promise<Result<Beneficiary[], UnexpectedBeneficiaryError>> {
+    try {
+      const beneficiaries = await this.prismaClient.beneficiary.findMany({
+        where: { clientIdentifier }
+      });
+      return ok(beneficiaries.map(b => this.prismaBeneficiaryMapper.toDomain(b)));
+    } catch (error: any) {
+      return err(new UnexpectedBeneficiaryError(`Error fetching beneficiaries for client ${clientIdentifier}: ${error.message}`, error));
+    }
+  }
+
+  async findByClientAndIban(clientIdentifier: string, iban: string): Promise<Result<Beneficiary | null, UnexpectedBeneficiaryError>> {
+    try {
+      const maybeBeneficiary = await this.prismaClient.beneficiary.findFirst({
+        where: { 
+          clientIdentifier,
+          iban
+        }
+      });
+
+      if (!maybeBeneficiary) {
+        return ok(null);
+      }
+
+      return ok(this.prismaBeneficiaryMapper.toDomain(maybeBeneficiary));
+    } catch (error: any) {
+      return err(new UnexpectedBeneficiaryError(`Error fetching beneficiary by client and IBAN: ${error.message}`, error));
+    }
+  }
+
+  async delete(beneficiaryIdentifier: string): Promise<Result<true, BeneficiaryNotFoundError | UnexpectedBeneficiaryError>> {
+    try {
+      await this.prismaClient.beneficiary.delete({
+        where: { beneficiaryIdentifier }
+      });
+      return ok(true);
+    } catch (error: any) {
+      if (error.code === 'P2025') {
+        return err(new BeneficiaryNotFoundError(beneficiaryIdentifier));
+      }
+      return err(new UnexpectedBeneficiaryError(`Error deleting beneficiary: ${error.message}`, error));
+    }
+  }
+
+  async updateLabel(beneficiaryIdentifier: string, label: string): Promise<Result<Beneficiary, BeneficiaryNotFoundError | UnexpectedBeneficiaryError>> {
+    try {
+      const updatedBeneficiary = await this.prismaClient.beneficiary.update({
+        where: { beneficiaryIdentifier },
+        data: { label }
+      });
+      return ok(this.prismaBeneficiaryMapper.toDomain(updatedBeneficiary));
+    } catch (error: any) {
+      if (error.code === 'P2025') {
+        return err(new BeneficiaryNotFoundError(beneficiaryIdentifier));
+      }
+      return err(new UnexpectedBeneficiaryError(`Error updating beneficiary label: ${error.message}`, error));
+    }
+  }
+}

--- a/backend/src/infrastructure/repositories/prisma/PrismaCompanyRepository.ts
+++ b/backend/src/infrastructure/repositories/prisma/PrismaCompanyRepository.ts
@@ -1,6 +1,7 @@
 import { PrismaClient } from "@prisma/client";
 import { CompanyRepository } from "../../../application/ports/repositories/CompanyRepository";
 import { Company } from "../../../domain/entities/Company";
+import { CompanyNotFoundError } from "../../../domain/errors/CompanyNotFoundError";
 import { CouldNotCreateCompanyError } from "../../../domain/errors/CouldNotCreateCompanyError";
 import Result, { err, ok } from "../../../shared/Result";
 import { PrismaCompanyMapper } from "../mappers/PrismaMappers/PrismaCompanyMapper";
@@ -28,11 +29,55 @@ export class PrismaCompanyRepository implements CompanyRepository {
     }
   }
 
-  async findById(): Promise<Result<Company, CompanyNotFoundError>> {
-    
+  async findById(companyIdentifier: string): Promise<Result<Company, CompanyNotFoundError>> {
+    try {
+      const maybeCompany = await this.prismaClient.company.findUnique({
+        where: { companyIdentifier }
+      });
+
+      if (!maybeCompany) {
+        return err(new CompanyNotFoundError(companyIdentifier));
+      }
+
+      return ok(this.prismaCompanyMapper.toDomain(maybeCompany));
+    } catch (error) {
+      return err(new CompanyNotFoundError(companyIdentifier));
+    }
   }
 
-  async all(): Promise<Result<Company, CompanyNotFoundError>> {
-    
+  async all(): Promise<Result<Company[], Error>> {
+    try {
+      const companies = await this.prismaClient.company.findMany();
+      return ok(companies.map(c => this.prismaCompanyMapper.toDomain(c)));
+    } catch (error: any) {
+      return err(new Error(`Error fetching all companies: ${error.message}`));
+    }
+  }
+
+  async update(company: Company): Promise<Result<Company, Error>> {
+    try {
+      const companyToPersist = this.prismaCompanyMapper.toPersistence(company);
+      const updatedCompany = await this.prismaClient.company.update({
+        where: { companyIdentifier: company.companyIdentifier },
+        data: {
+          name: companyToPersist.name,
+          description: companyToPersist.description
+        }
+      });
+      return ok(this.prismaCompanyMapper.toDomain(updatedCompany));
+    } catch (error: any) {
+      return err(new Error(`Error updating company: ${error.message}`));
+    }
+  }
+
+  async delete(companyIdentifier: string): Promise<Result<void, Error>> {
+    try {
+      await this.prismaClient.company.delete({
+        where: { companyIdentifier }
+      });
+      return ok(undefined);
+    } catch (error: any) {
+      return err(new Error(`Error deleting company: ${error.message}`));
+    }
   }
 }

--- a/backend/src/infrastructure/repositories/prisma/PrismaStockRepository.ts
+++ b/backend/src/infrastructure/repositories/prisma/PrismaStockRepository.ts
@@ -1,0 +1,116 @@
+import { PrismaClient } from "@prisma/client";
+import { StockRepository } from "../../../application/ports/repositories/StockRepository";
+import { Stock } from "../../../domain/entities/Stock";
+import { StockNotFoundError } from "../../../domain/errors/StockNotFoundError";
+import Result, { err, ok } from "../../../shared/Result";
+import { PrismaStockMapper } from "../mappers/PrismaMappers/PrismaStockMapper";
+
+export class PrismaStockRepository implements StockRepository {
+  constructor(
+    private readonly prismaClient: PrismaClient,
+    private readonly prismaStockMapper: PrismaStockMapper
+  ) {}
+
+  async save(stock: Stock): Promise<Result<Stock, Error>> {
+    try {
+      const stockToPersist = this.prismaStockMapper.toPersistence(stock);
+      const registeredStock = await this.prismaClient.stock.create({
+        data: { ...stockToPersist }
+      });
+      return ok(this.prismaStockMapper.toDomain(registeredStock));
+    } catch (error: any) {
+      return err(new Error(`Error saving stock: ${error.message}`));
+    }
+  }
+
+  async findById(stockIdentifier: string): Promise<Result<Stock, StockNotFoundError>> {
+    try {
+      const maybeStock = await this.prismaClient.stock.findUnique({
+        where: { stockIdentifier }
+      });
+
+      if (!maybeStock) {
+        return err(new StockNotFoundError(stockIdentifier));
+      }
+
+      return ok(this.prismaStockMapper.toDomain(maybeStock));
+    } catch (error) {
+      return err(new StockNotFoundError(stockIdentifier));
+    }
+  }
+
+  async findByTicker(ticker: string): Promise<Result<Stock, StockNotFoundError>> {
+    try {
+      const maybeStock = await this.prismaClient.stock.findUnique({
+        where: { ticker }
+      });
+
+      if (!maybeStock) {
+        return err(new StockNotFoundError(ticker));
+      }
+
+      return ok(this.prismaStockMapper.toDomain(maybeStock));
+    } catch (error) {
+      return err(new StockNotFoundError(ticker));
+    }
+  }
+
+  async findByCompanyId(companyId: string): Promise<Result<Stock[], Error>> {
+    try {
+      const stocks = await this.prismaClient.stock.findMany({
+        where: { companyIdentifier: companyId }
+      });
+      return ok(stocks.map(s => this.prismaStockMapper.toDomain(s)));
+    } catch (error: any) {
+      return err(new Error(`Error fetching stocks for company ${companyId}: ${error.message}`));
+    }
+  }
+
+  async update(stock: Stock): Promise<Result<Stock, StockNotFoundError>> {
+    try {
+      const stockToPersist = this.prismaStockMapper.toPersistence(stock);
+      const updatedStock = await this.prismaClient.stock.update({
+        where: { stockIdentifier: stock.stockIdentifier },
+        data: {
+          ticker: stockToPersist.ticker,
+          price: stockToPersist.price,
+          isAvailable: stockToPersist.isAvailable
+        }
+      });
+      return ok(this.prismaStockMapper.toDomain(updatedStock));
+    } catch (error) {
+      return err(new StockNotFoundError(stock.stockIdentifier));
+    }
+  }
+
+  async remove(id: string): Promise<Result<true, StockNotFoundError>> {
+    try {
+      await this.prismaClient.stock.delete({
+        where: { stockIdentifier: id }
+      });
+      return ok(true);
+    } catch (error) {
+      return err(new StockNotFoundError(id));
+    }
+  }
+
+  async all(): Promise<Result<Stock[], Error>> {
+    try {
+      const stocks = await this.prismaClient.stock.findMany();
+      return ok(stocks.map(s => this.prismaStockMapper.toDomain(s)));
+    } catch (error: any) {
+      return err(new Error(`Error fetching all stocks: ${error.message}`));
+    }
+  }
+
+  async allAvailableStocks(): Promise<Result<Stock[], Error>> {
+    try {
+      const stocks = await this.prismaClient.stock.findMany({
+        where: { isAvailable: true }
+      });
+      return ok(stocks.map(s => this.prismaStockMapper.toDomain(s)));
+    } catch (error: any) {
+      return err(new Error(`Error fetching available stocks: ${error.message}`));
+    }
+  }
+}

--- a/backend/src/infrastructure/repositories/prisma/schema.prisma
+++ b/backend/src/infrastructure/repositories/prisma/schema.prisma
@@ -78,9 +78,11 @@ model Transaction{
   direction TransactionDirection
   type TransactionType
   description String
+  currency String @default("EUR")
   date DateTime @default(now())
   fromAccountIdentifier String?
   toAccountIdentifier String?
+  toSavingAccountIdentifier String?
 
   bankAccount BankAccount @relation(fields: [bankAccountIdentifier], references: [accountIdentifier])
 }
@@ -139,6 +141,7 @@ model Loan {
 }
 
 enum LoanStatus {
+  PENDING
   ACTIVE
   PAID_OFF
 }
@@ -154,6 +157,7 @@ model Stock {
   orders Order[]
   holding Holding[]
   trades Trade[]
+  priceHistory StockPriceHistory[]
 
 }
 
@@ -244,4 +248,22 @@ model SavingProduct {
   rate Float
 
   savingAccounts SavingAccount[]
+}
+
+model Beneficiary {
+  beneficiaryIdentifier String @id @default(cuid())
+  clientIdentifier String
+  iban String
+  label String
+  accountName String?
+  createdAt DateTime @default(now())
+}
+
+model StockPriceHistory {
+  stockPriceIdentifier String @id @default(cuid())
+  stockIdentifier String
+  price Float
+  recordedAt DateTime @default(now())
+
+  stock Stock @relation(fields: [stockIdentifier], references: [stockIdentifier])
 }

--- a/backend/tests/helpers/createPrismaTestDb.ts
+++ b/backend/tests/helpers/createPrismaTestDb.ts
@@ -1,0 +1,108 @@
+import { PrismaClient } from '@prisma/client';
+import { PrismaPg } from '@prisma/adapter-pg';
+import { Pool } from 'pg';
+import { execSync } from 'child_process';
+import path from 'path';
+
+/**
+ * Helper pour créer une connexion de test Prisma (Prisma 7.x).
+ * 
+ * IMPORTANT: Pour les tests Prisma, vous devez:
+ * 1. Configurer une base PostgreSQL de test (ex: cleanavenir_test)
+ * 2. Définir DATABASE_URL_TEST dans votre .env.test ou en variable d'environnement
+ * 3. Exécuter `DATABASE_URL=$DATABASE_URL_TEST npx prisma db push` avant les tests
+ * 
+ * Ou utiliser un conteneur Docker PostgreSQL pour les tests:
+ * docker run --name postgres-test -e POSTGRES_PASSWORD=test -e POSTGRES_DB=cleanavenir_test -p 5433:5432 -d postgres
+ * DATABASE_URL_TEST="postgresql://postgres:test@localhost:5433/cleanavenir_test"
+ */
+
+let pool: Pool | null = null;
+
+export async function createPrismaTestDb(): Promise<PrismaClient> {
+  const testDatabaseUrl = process.env.DATABASE_URL_TEST || process.env.DATABASE_URL;
+  
+  if (!testDatabaseUrl) {
+    throw new Error(
+      'DATABASE_URL_TEST ou DATABASE_URL doit être défini pour les tests Prisma.\n' +
+      'Exemple: DATABASE_URL_TEST="postgresql://postgres:test@localhost:5433/cleanavenir_test"'
+    );
+  }
+
+  // Synchronise le schéma avec la base de données de test
+  try {
+    const schemaPath = path.join(process.cwd(), 'src/infrastructure/repositories/prisma/schema.prisma');
+    execSync(
+      `npx prisma db push --schema="${schemaPath}" --skip-generate --accept-data-loss`, 
+      {
+        cwd: process.cwd(),
+        stdio: 'pipe',
+        env: {
+          ...process.env,
+          DATABASE_URL: testDatabaseUrl
+        }
+      }
+    );
+  } catch (error: any) {
+    // On continue quand même, le schéma est peut-être déjà à jour
+  }
+
+  // Créer le pool de connexion PostgreSQL
+  pool = new Pool({ connectionString: testDatabaseUrl });
+  
+  // Créer l'adaptateur Prisma pour PostgreSQL
+  const adapter = new PrismaPg(pool);
+  
+  // Configure le client Prisma avec l'adaptateur
+  const prisma = new PrismaClient({ adapter });
+
+  return prisma;
+}
+
+// Helper pour nettoyer la connexion après les tests
+export async function cleanupPrismaTestDb(prisma: PrismaClient): Promise<void> {
+  if (prisma) {
+    await prisma.$disconnect();
+  }
+  if (pool) {
+    await pool.end();
+    pool = null;
+  }
+}
+
+/**
+ * Helper pour nettoyer les données de test (optionnel).
+ * À utiliser dans beforeEach/afterEach si nécessaire.
+ */
+export async function clearPrismaTestData(prisma: PrismaClient): Promise<void> {
+  // Supprime les données dans l'ordre inverse des dépendances
+  const tableNames = [
+    'StockPriceHistory',
+    'Trade',
+    'Order',
+    'Holding',
+    'Portfolio',
+    'Transaction',
+    'BankAccount',
+    'SavingAccount',
+    'Loan',
+    'Discussion',
+    'Beneficiary',
+    'Stock',
+    'Company',
+    'SavingProduct',
+    'Client',
+    'Director',
+    'Advisor',
+    'User'
+  ];
+
+  for (const tableName of tableNames) {
+    try {
+      await prisma.$executeRawUnsafe(`DELETE FROM "${tableName}"`);
+    } catch (e) {
+      // Ignorer les erreurs si la table n'existe pas encore
+    }
+  }
+}
+

--- a/backend/tests/prisma-beneficiary-repo.test.ts
+++ b/backend/tests/prisma-beneficiary-repo.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { PrismaClient } from '@prisma/client';
+import { randomUUID } from 'crypto';
+import { PrismaBeneficiaryMapper } from '../src/infrastructure/repositories/mappers/PrismaMappers/PrismaBeneficiaryMapper';
+import { PrismaBeneficiaryRepository } from '../src/infrastructure/repositories/prisma/PrismaBeneficiaryRepository';
+import { Beneficiary } from '../src/domain/entities/Beneficiary';
+import { Iban } from '../src/domain/value-objects/Iban';
+import { createPrismaTestDb, cleanupPrismaTestDb } from './helpers/createPrismaTestDb';
+
+describe('Prisma Beneficiary repository', () => {
+  let prisma: PrismaClient;
+  let beneficiaryRepository: PrismaBeneficiaryRepository;
+  const beneficiaryMapper = new PrismaBeneficiaryMapper();
+
+  // Helper pour générer un IBAN valide (27-36 caractères)
+  const generateValidIban = () => `FR76${randomUUID().replace(/-/g, '').slice(0, 23)}`;
+
+  beforeAll(async () => {
+    prisma = await createPrismaTestDb();
+    beneficiaryRepository = new PrismaBeneficiaryRepository(prisma, beneficiaryMapper);
+  });
+
+  afterAll(async () => {
+    await cleanupPrismaTestDb(prisma);
+  });
+
+  it('peut insérer et retrouver un bénéficiaire', async () => {
+    const beneficiaryId = randomUUID();
+    const clientId = randomUUID();
+    const ibanValue = generateValidIban();
+
+    const ibanResult = Iban.from(ibanValue);
+    expect(ibanResult.ok).toBe(true);
+    if (!ibanResult.ok) return;
+
+    const beneficiary = Beneficiary.create({
+      beneficiaryIdentifier: beneficiaryId,
+      clientIdentifier: clientId,
+      iban: ibanResult.value,
+      label: 'Test Beneficiary',
+      accountName: 'John Doe',
+      createdAt: new Date()
+    });
+
+    // Sauvegarder le bénéficiaire
+    const saveResult = await beneficiaryRepository.save(beneficiary);
+    expect(saveResult.ok).toBe(true);
+
+    // Retrouver par ID
+    const findResult = await beneficiaryRepository.findById(beneficiaryId);
+    expect(findResult.ok).toBe(true);
+    if (findResult.ok) {
+      expect(findResult.value.beneficiaryIdentifier).toBe(beneficiaryId);
+      expect(findResult.value.label).toBe('Test Beneficiary');
+      expect(findResult.value.accountName).toBe('John Doe');
+    }
+  });
+
+  it('peut lister les bénéficiaires par client', async () => {
+    const clientId = randomUUID();
+    const beneficiary1Id = randomUUID();
+    const beneficiary2Id = randomUUID();
+
+    const iban1Result = Iban.from(generateValidIban());
+    const iban2Result = Iban.from(generateValidIban());
+    if (!iban1Result.ok || !iban2Result.ok) return;
+
+    const beneficiary1 = Beneficiary.create({
+      beneficiaryIdentifier: beneficiary1Id,
+      clientIdentifier: clientId,
+      iban: iban1Result.value,
+      label: 'Bénéficiaire 1',
+      createdAt: new Date()
+    });
+
+    const beneficiary2 = Beneficiary.create({
+      beneficiaryIdentifier: beneficiary2Id,
+      clientIdentifier: clientId,
+      iban: iban2Result.value,
+      label: 'Bénéficiaire 2',
+      createdAt: new Date()
+    });
+
+    await beneficiaryRepository.save(beneficiary1);
+    await beneficiaryRepository.save(beneficiary2);
+
+    const listResult = await beneficiaryRepository.findByClientIdentifier(clientId);
+    expect(listResult.ok).toBe(true);
+    if (listResult.ok) {
+      expect(listResult.value.length).toBe(2);
+    }
+  });
+
+  it('peut retrouver un bénéficiaire par client et IBAN', async () => {
+    const clientId = randomUUID();
+    const beneficiaryId = randomUUID();
+    const ibanValue = generateValidIban();
+
+    const ibanResult = Iban.from(ibanValue);
+    if (!ibanResult.ok) return;
+
+    const beneficiary = Beneficiary.create({
+      beneficiaryIdentifier: beneficiaryId,
+      clientIdentifier: clientId,
+      iban: ibanResult.value,
+      label: 'IBAN Search Test',
+      createdAt: new Date()
+    });
+
+    await beneficiaryRepository.save(beneficiary);
+
+    const findResult = await beneficiaryRepository.findByClientAndIban(clientId, ibanValue);
+    expect(findResult.ok).toBe(true);
+    if (findResult.ok && findResult.value) {
+      expect(findResult.value.iban.value).toBe(ibanValue);
+    }
+  });
+
+  it('retourne null si bénéficiaire non trouvé par client et IBAN', async () => {
+    const findResult = await beneficiaryRepository.findByClientAndIban('non-existent', 'FR7600000000000000000000000');
+    expect(findResult.ok).toBe(true);
+    if (findResult.ok) {
+      expect(findResult.value).toBeNull();
+    }
+  });
+
+  it('peut mettre à jour le label d\'un bénéficiaire', async () => {
+    const beneficiaryId = randomUUID();
+    const clientId = randomUUID();
+    const ibanValue = generateValidIban();
+
+    const ibanResult = Iban.from(ibanValue);
+    if (!ibanResult.ok) return;
+
+    const beneficiary = Beneficiary.create({
+      beneficiaryIdentifier: beneficiaryId,
+      clientIdentifier: clientId,
+      iban: ibanResult.value,
+      label: 'Original Label',
+      createdAt: new Date()
+    });
+
+    await beneficiaryRepository.save(beneficiary);
+
+    const updateResult = await beneficiaryRepository.updateLabel(beneficiaryId, 'Nouveau Label');
+    expect(updateResult.ok).toBe(true);
+    if (updateResult.ok) {
+      expect(updateResult.value.label).toBe('Nouveau Label');
+    }
+  });
+
+  it('retourne une erreur pour un bénéficiaire non trouvé', async () => {
+    const findResult = await beneficiaryRepository.findById('non-existent-id');
+    expect(findResult.ok).toBe(false);
+  });
+
+  it('peut supprimer un bénéficiaire', async () => {
+    const beneficiaryId = randomUUID();
+    const clientId = randomUUID();
+    const ibanValue = generateValidIban();
+
+    const ibanResult = Iban.from(ibanValue);
+    if (!ibanResult.ok) return;
+
+    const beneficiary = Beneficiary.create({
+      beneficiaryIdentifier: beneficiaryId,
+      clientIdentifier: clientId,
+      iban: ibanResult.value,
+      label: 'To Delete',
+      createdAt: new Date()
+    });
+
+    await beneficiaryRepository.save(beneficiary);
+
+    const deleteResult = await beneficiaryRepository.delete(beneficiaryId);
+    expect(deleteResult.ok).toBe(true);
+
+    // Vérifier que le bénéficiaire n'existe plus
+    const findResult = await beneficiaryRepository.findById(beneficiaryId);
+    expect(findResult.ok).toBe(false);
+  });
+
+  it('retourne une erreur lors de la suppression d\'un bénéficiaire non existant', async () => {
+    const deleteResult = await beneficiaryRepository.delete('non-existent-id');
+    expect(deleteResult.ok).toBe(false);
+  });
+});

--- a/backend/tests/prisma-stock-repo.test.ts
+++ b/backend/tests/prisma-stock-repo.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { PrismaClient } from '@prisma/client';
+import { randomUUID } from 'crypto';
+import { PrismaStockMapper } from '../src/infrastructure/repositories/mappers/PrismaMappers/PrismaStockMapper';
+import { PrismaStockRepository } from '../src/infrastructure/repositories/prisma/PrismaStockRepository';
+import { Stock } from '../src/domain/entities/Stock';
+import { Ticker } from '../src/domain/value-objects/Ticker';
+import { createPrismaTestDb, cleanupPrismaTestDb } from './helpers/createPrismaTestDb';
+
+describe('Prisma Stock repository', () => {
+  let prisma: PrismaClient;
+  let stockRepository: PrismaStockRepository;
+  const stockMapper = new PrismaStockMapper();
+
+  beforeAll(async () => {
+    prisma = await createPrismaTestDb();
+    stockRepository = new PrismaStockRepository(prisma, stockMapper);
+  });
+
+  afterAll(async () => {
+    await cleanupPrismaTestDb(prisma);
+  });
+
+  it('peut insérer et retrouver un stock', async () => {
+    const stockId = randomUUID();
+    const companyId = randomUUID();
+    const tickerValue = `TST${stockId.slice(0, 4).toUpperCase()}`;
+
+    // D'abord créer une company pour la relation
+    await prisma.company.create({
+      data: {
+        companyIdentifier: companyId,
+        name: 'Test Company',
+        description: 'Une entreprise de test'
+      }
+    });
+
+    const tickerResult = Ticker.from(tickerValue);
+    expect(tickerResult.ok).toBe(true);
+    if (!tickerResult.ok) return;
+
+    const stock = Stock.create({
+      stockIdentifier: stockId,
+      companyIdentifier: companyId,
+      ticker: tickerResult.value,
+      price: 100.50,
+      isAvailable: true,
+      createdAt: new Date()
+    });
+
+    // Sauvegarder le stock
+    const saveResult = await stockRepository.save(stock);
+    expect(saveResult.ok).toBe(true);
+
+    // Retrouver par ID
+    const findResult = await stockRepository.findById(stockId);
+    expect(findResult.ok).toBe(true);
+    if (findResult.ok) {
+      expect(findResult.value.stockIdentifier).toBe(stockId);
+      expect(findResult.value.ticker.value).toBe(tickerValue);
+      expect(findResult.value.price).toBe(100.50);
+    }
+  });
+
+  it('peut retrouver un stock par ticker', async () => {
+    const stockId = randomUUID();
+    const companyId = randomUUID();
+    const tickerValue = `TCK${stockId.slice(0, 4).toUpperCase()}`;
+
+    await prisma.company.create({
+      data: {
+        companyIdentifier: companyId,
+        name: 'Ticker Test Company',
+        description: 'Test'
+      }
+    });
+
+    const tickerResult = Ticker.from(tickerValue);
+    expect(tickerResult.ok).toBe(true);
+    if (!tickerResult.ok) return;
+
+    const stock = Stock.create({
+      stockIdentifier: stockId,
+      companyIdentifier: companyId,
+      ticker: tickerResult.value,
+      price: 50.25,
+      isAvailable: true,
+      createdAt: new Date()
+    });
+
+    await stockRepository.save(stock);
+
+    const findResult = await stockRepository.findByTicker(tickerValue);
+    expect(findResult.ok).toBe(true);
+    if (findResult.ok) {
+      expect(findResult.value.ticker.value).toBe(tickerValue);
+    }
+  });
+
+  it('peut mettre à jour un stock', async () => {
+    const stockId = randomUUID();
+    const companyId = randomUUID();
+    const tickerValue = `UPD${stockId.slice(0, 4).toUpperCase()}`;
+
+    await prisma.company.create({
+      data: {
+        companyIdentifier: companyId,
+        name: 'Update Test Company',
+        description: 'Test'
+      }
+    });
+
+    const tickerResult = Ticker.from(tickerValue);
+    if (!tickerResult.ok) return;
+
+    const stock = Stock.create({
+      stockIdentifier: stockId,
+      companyIdentifier: companyId,
+      ticker: tickerResult.value,
+      price: 100,
+      isAvailable: true,
+      createdAt: new Date()
+    });
+
+    await stockRepository.save(stock);
+
+    // Mettre à jour le prix
+    stock.updatePrice(150);
+    const updateResult = await stockRepository.update(stock);
+    expect(updateResult.ok).toBe(true);
+    if (updateResult.ok) {
+      expect(updateResult.value.price).toBe(150);
+    }
+  });
+
+  it('peut lister tous les stocks', async () => {
+    const allResult = await stockRepository.all();
+    expect(allResult.ok).toBe(true);
+    if (allResult.ok) {
+      expect(allResult.value.length).toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  it('peut lister uniquement les stocks disponibles', async () => {
+    const availableResult = await stockRepository.allAvailableStocks();
+    expect(availableResult.ok).toBe(true);
+    if (availableResult.ok) {
+      availableResult.value.forEach(stock => {
+        expect(stock.isAvailable).toBe(true);
+      });
+    }
+  });
+
+  it('retourne une erreur pour un stock non trouvé', async () => {
+    const findResult = await stockRepository.findById('non-existent-id');
+    expect(findResult.ok).toBe(false);
+  });
+
+  it('peut supprimer un stock', async () => {
+    const stockId = randomUUID();
+    const companyId = randomUUID();
+    const tickerValue = `DEL${stockId.slice(0, 4).toUpperCase()}`;
+
+    await prisma.company.create({
+      data: {
+        companyIdentifier: companyId,
+        name: 'Delete Test Company',
+        description: 'Test'
+      }
+    });
+
+    const tickerResult = Ticker.from(tickerValue);
+    if (!tickerResult.ok) return;
+
+    const stock = Stock.create({
+      stockIdentifier: stockId,
+      companyIdentifier: companyId,
+      ticker: tickerResult.value,
+      price: 75,
+      isAvailable: true,
+      createdAt: new Date()
+    });
+
+    await stockRepository.save(stock);
+
+    const removeResult = await stockRepository.remove(stockId);
+    expect(removeResult.ok).toBe(true);
+
+    // Vérifier que le stock n'existe plus
+    const findResult = await stockRepository.findById(stockId);
+    expect(findResult.ok).toBe(false);
+  });
+});


### PR DESCRIPTION
- Add PrismaStockRepository with full CRUD operations
- Add PrismaBeneficiaryRepository with full CRUD operations
- Add PrismaBeneficiaryMapper and update PrismaStockMapper
- Complete PrismaCompanyRepository (findById, all, update, delete)
- Update schema.prisma: add Beneficiary, StockPriceHistory models
- Add currency and toSavingAccountIdentifier to Transaction
- Add PENDING status to LoanStatus enum
- Add Prisma 7.x test helper with @prisma/adapter-pg
- Add integration tests for Stock and Beneficiary repos
- Update README with Prisma test instructions